### PR TITLE
resin-image.inc: Add WiFi, BT firmware and dependencies to rootfs

### DIFF
--- a/layers/meta-resin-imx6ul-var-dart/recipes-core/images/resin-image.inc
+++ b/layers/meta-resin-imx6ul-var-dart/recipes-core/images/resin-image.inc
@@ -58,3 +58,10 @@ IMAGE_INSTALL_append_imx7-var-som = " \
 				     linux-firmware-bcm43430 \
 				     brcm-patchram-plus \
 "
+
+IMAGE_INSTALL_append_imx6ul-var-dart = " \
+    bcm43xx-utils \
+    linux-firmware-bcm4339 \
+    linux-firmware-bcm43430 \
+    brcm-patchram-plus \
+"


### PR DESCRIPTION
Changelog-entry: Add WiFi, BT firmware and dependencies to rootfs for imx6ul-var-dart
Signed-off-by: Florin Sarbu <florin@balena.io>